### PR TITLE
Supplement to `post-title` branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 .vercel
 
 package-lock.json
+
+# editors
+.idea

--- a/package.json
+++ b/package.json
@@ -33,14 +33,15 @@
     "styled-media-query": "^2.1.2"
   },
   "devDependencies": {
-    "@types/node": "^16.9.1",
-    "babel-plugin-styled-components": "^1.13.2",
     "@babel/core": "^7.15.8",
+    "@types/node": "^16.9.1",
     "@types/nprogress": "^0.2.0",
     "@types/react": "17.0.21",
     "@types/styled-components": "^5.1.14",
     "autoprefixer": "^10.3.7",
     "babel-plugin-macros": "^3.1.0",
+    "babel-plugin-styled-components": "^1.13.2",
+    "esbuild": "^0.13.10",
     "eslint": "7.32.0",
     "eslint-config-next": "11.1.2",
     "postcss": "^8.3.10",


### PR DESCRIPTION
I added `esbuild` dependency because `mdx-bundler` needs this dependency to work properly